### PR TITLE
Fix broken link in pciemu.h

### DIFF
--- a/src/hw/pciemu/pciemu.h
+++ b/src/hw/pciemu/pciemu.h
@@ -18,7 +18,7 @@
 #define PCIEMU_DEVICE_DESC "PCIEMU Device"
 /*
  * Declare the object type for PCIEMUDevice and all boilerplate code
- * See https://qemu.readthedocs.io/en/latest/devel/qom.html for details
+ * See https://qemu.readthedocs.io/en/master/devel/qom.html for details
  *
  */
 OBJECT_DECLARE_TYPE(PCIEMUDevice, PCIEMUDeviceClass, PCIEMU_DEVICE);


### PR DESCRIPTION
The current link leads to an unexisting page.
Maybe it should lead to some tag instead of master, but right now it just leads to 404 error.